### PR TITLE
Support 18 Character Org Ids

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -49,6 +49,5 @@ class AccessToken extends \League\OAuth2\Client\Token\AccessToken
         return preg_match('/' . self::ORG_ID_PREFIX .  '(\w{15}|\w{12})/', $this->getResourceOwnerId(), $result)
             ? $result[0]
             : null;
-
     }
 }

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -46,7 +46,7 @@ class AccessToken extends \League\OAuth2\Client\Token\AccessToken
      */
     public function getOrgId()
     {
-        return preg_match('/' . self::ORG_ID_PREFIX .  '(\w{12}|\w{15})/', $this->getResourceOwnerId(), $result)
+        return preg_match('/' . self::ORG_ID_PREFIX .  '(\w{15}|\w{12})/', $this->getResourceOwnerId(), $result)
             ? $result[0]
             : null;
 

--- a/tests/src/Token/AccessTokenTest.php
+++ b/tests/src/Token/AccessTokenTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace Stevenmaguire\OAuth2\Client\Test\Token;
+
+use Stevenmaguire\OAuth2\Client\Provider\Salesforce;
+use Stevenmaguire\OAuth2\Client\Token\AccessToken;
+
+class AccessTokenTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getJson()
+    {
+        $json = file_get_contents(dirname(dirname(dirname(__FILE__))) . '/access_token_response.json');
+        $data = json_decode($json, true);
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider orgIdDataProvider
+     *
+     * @param string      $expectedOrgId
+     * @param AccessToken $accessToken
+     */
+    public function testOrgIdMatchesExpectedOutput($expectedOrgId, AccessToken $accessToken)
+    {
+        $this->assertEquals($expectedOrgId, $accessToken->getOrgId());
+    }
+
+    public function orgIdDataProvider()
+    {
+        return [
+            [ // 15 character ID
+                '00Dx0000001T0zk',
+                $this->getAccessToken('00Dx0000001T0zk')
+            ],
+            [ // 18 character ID
+                '00Dx0000001T0zkEAY',
+                $this->getAccessToken('00Dx0000001T0zkEAY')
+            ]
+        ];
+    }
+
+    public function getAccessToken($orgId = null)
+    {
+        $data = $this->getJson();
+
+        if (!is_null($orgId)) {
+            $data['resource_owner_id'] = sprintf('http://na1.salesforce.com/id/%s/005x0000001S2b9', $orgId);
+        } else {
+            $data['resource_owner_id'] = $data[Salesforce::ACCESS_TOKEN_RESOURCE_OWNER_ID];
+        }
+
+        return new AccessToken($data);
+    }
+}


### PR DESCRIPTION
The regex in the `AccessToken::getOrgId()` method first attempted to
match the Org prefix followed by 12 OR 15 word characters. This resulted
in org IDs of 18 characters being stripped to 15 characters in length.

The fix for this was to reverse the match - first try and match the Org
prefix followed by 15 characters *then* 12 characters for older org IDs.

This PR simply reverses the order of length checking for the organization ID. It also adds a new `AccessTokenTest` class to cover both 15 and 18 character Org IDs.

---

I recommend tagging a new 0.3.1 version if this is accepted.