### PR TITLE
Let refresh_token be a default scope

### DIFF
--- a/src/Provider/Salesforce.php
+++ b/src/Provider/Salesforce.php
@@ -69,7 +69,8 @@ class Salesforce extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return [];
+        // refresh_token scope is required for Salesforce to return a refresh_token upon authentication
+        return ['refresh_token'];
     }
 
     /**


### PR DESCRIPTION
If you do not pass the refresh_token scope, the refresh token is not provided upon authenticating with Salesforce. This seems like a reasonable default scope as the refresh token is necessary to use this client provider once the expiration period has passed. Please consider. Thanks!