### PR TITLE
Update provider exception message

### DIFF
--- a/src/Provider/Salesforce.php
+++ b/src/Provider/Salesforce.php
@@ -106,7 +106,7 @@ class Salesforce extends AbstractProvider
         $statusCode = $response->getStatusCode();
         if ($statusCode >= 400) {
             throw new IdentityProviderException(
-                isset($data[0]['message']) ? $data[0]['message'] : $response->getReasonPhrase(),
+                isset($data['error_description']) ? $data['error_description'] : $response->getReasonPhrase(),
                 $statusCode,
                 $response
             );


### PR DESCRIPTION
Throw `IdentityProviderException` with correct error message.
Reference: [OAuth 2.0 Authorization Errors](https://help.salesforce.com/articleView?id=remoteaccess_oauth_flow_errors.htm&type=5)